### PR TITLE
Fixes parsing problem with directly nested paralogGroup nodes in orthoxml

### DIFF
--- a/pyham/parsers.py
+++ b/pyham/parsers.py
@@ -101,9 +101,14 @@ class OrthoXMLParser(object):
                 self._build_gene(attrib)
 
         elif tag == "{http://orthoXML.org/2011/}paralogGroup" and self.skip_this_hog is False:
-            dNode = abstractgene.DuplicationNode(self.ham_object)
+            cur_depth = len(self.hog_stack)
+            if len(self.paralog_stack)>0 and self.paralog_stack[-1]['depth'] == cur_depth:
+                # we have a directly nested paralog group. use the same DuplicationNode
+                dNode = self.paralog_stack[-1]['node']
+            else:
+                dNode = abstractgene.DuplicationNode(self.ham_object)
 
-            self.paralog_stack.append({'depth': len(self.hog_stack), 'node': dNode})
+            self.paralog_stack.append({'depth': cur_depth, 'node': dNode})
 
             self.in_paralogGroup = self.paralog_stack[-1]['depth']
             self.paralogyNode = self.paralog_stack[-1]['node']

--- a/tests/data/multiple_duplication_example.xml
+++ b/tests/data/multiple_duplication_example.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<orthoXML xsi:schemaLocation="http://orthoXML.org http://orthoXML.org/0.3/orthoxml.xsd" version="0.3" origin="Ensembl" originVersion="Unknown" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://orthoXML.org/2011/">
+  <species NCBITaxId="158456" name="betta_splendens">
+    <database name="Unknown" version="fBetSpl5.2/2019-05-Ensembl">
+      <genes>
+        <gene id="948443112" geneId="ENSBSLG00000016595" protId="ENSBSLP00000034367" />
+        <gene id="949090975" geneId="ENSBSLG00000022939" protId="ENSBSLP00000048205" />
+        <gene id="948280354" geneId="ENSBSLG00000007050" protId="ENSBSLP00000013302" />
+        <gene id="948946073" geneId="ENSBSLG00000012101" protId="ENSBSLP00000023746" />
+      </genes>
+    </database>
+  </species>
+  <species name="anabas_testudineus">
+    <database name="Unknown" version="BROADS1/2006-06-Ensembl">
+      <genes>
+        <gene id="705198" geneId="ENSGACG00000019378" protId="ENSGACP00000025614" />
+      </genes>
+    </database>
+  </species>
+  <groups>
+    <orthologGroup id="1">
+      <paralogGroup id="2">
+        <property name="taxon_name" value="Betta splendens" />
+        <paralogGroup id="3">
+          <property name="taxon_name" value="Betta splendens" />
+          <geneRef id="948280354" />
+          <geneRef id="948443112" />
+        </paralogGroup>
+        <paralogGroup id="4">
+          <property name="taxon_name" value="Betta splendens" />
+          <geneRef id="949090975" />
+          <geneRef id="948946073" />
+        </paralogGroup>
+      </paralogGroup>
+      <geneRef id="705198" />
+    </orthologGroup>
+  </groups>
+</orthoXML>

--- a/tests/data/simpleEx_complexParalogs.orthoxml
+++ b/tests/data/simpleEx_complexParalogs.orthoxml
@@ -206,6 +206,6 @@ Example Notes without meaning
     </paralogGroup>
    </orthologGroup>
   </orthologGroup>
-
+git lo
  </groups>
 </orthoXML>

--- a/tests/test_orthoxmlparser.py
+++ b/tests/test_orthoxmlparser.py
@@ -539,6 +539,23 @@ class OrthoXMLParser_Weird_Element_In_duplicationChildren(unittest.TestCase):
                         self.assertTrue(e in sub_hog.children)
 
 
+class TestParsingMultipleDuplicationExample(unittest.TestCase):
+    def setUp(self):
+        self.nwk_str = "(betta_splendens,anabas_testudineus);"
+        self.orthoxml_path = os.path.join(os.path.dirname(__file__), "data", "multiple_duplication_example.xml")
+
+    def test_parser_accepts_multiple_consequative_dups(self):
+        ham_analysis = ham.Ham(tree_file=self.nwk_str, hog_file=self.orthoxml_path, type_hog_file='orthoxml',
+                               use_internal_name=True)
+        hogs = ham_analysis.get_list_top_level_hogs()
+        self.assertEqual(1, len(hogs))
+        hog = hogs[0]
+        self.assertEqual(5, len(hog.children))
+        self.assertFalse(hog.children[0].arose_by_duplication)
+        dup_events = {g.arose_by_duplication for g in hog.children[1:]}
+        self.assertEqual(1, len(dup_events))
+
+
 class TestAugmentedOrthoxmlExample(unittest.TestCase):
     def setUp(self):
         self.phyloxml_path = os.path.join(os.path.dirname(__file__), "data", "p53_augmented_speciestree.phyloxml")


### PR DESCRIPTION
- adding failing test for directly nested paralog group example
- fixes problem with directly nested paralogGroup nodes
